### PR TITLE
Hide unused language models

### DIFF
--- a/resources/default-config.clj
+++ b/resources/default-config.clj
@@ -1,20 +1,20 @@
 {
-  :fr$core {:corpus ["fr.time"
-                    "fr.numbers"
-                    "fr.temperature"
-                    "fr.measure"
-                    "fr.finance"
-                    "en.communication"
-                    ]
-            :rules ["fr.time"
-                    "fr.numbers"
-                    "fr.cycles"
-                    "fr.duration"
-                    "fr.temperature"
-                    "fr.measure"
-                    "en.finance"                             ; sic
-                    "en.communication"
-                    ]}                     
+  ;:fr$core {:corpus ["fr.time"
+  ;                  "fr.numbers"
+  ;                  "fr.temperature"
+  ;                  "fr.measure"
+  ;                  "fr.finance"
+  ;                  "en.communication"
+  ;                  ]
+  ;          :rules ["fr.time"
+  ;                  "fr.numbers"
+  ;                  "fr.cycles"
+  ;                  "fr.duration"
+  ;                  "fr.temperature"
+  ;                  "fr.measure"
+  ;                  "en.finance"                             ; sic
+  ;                  "en.communication"
+  ;                  ]}
  :en$core {:corpus ["en.time"
                     "en.numbers"
                     "en.temperature"
@@ -45,22 +45,22 @@
                     "en.finance"
                     "en.communication"
                     ]}
-:et$core {:corpus [
-                    "et.numbers"
-                    ]
-           :rules  [
-                    "et.numbers"
-                    ]}
-:it$core {:corpus [
-                    "it.time"
-                    "it.numbers"
-                   ]
-            :rules [
-                     "it.time"
-                     "it.numbers"
-                     "it.cycles"
-                     "it.duration"
-                    ]}
+;:et$core {:corpus [
+;                    "et.numbers"
+;                    ]
+;           :rules  [
+;                    "et.numbers"
+;                    ]}
+;:it$core {:corpus [
+;                    "it.time"
+;                    "it.numbers"
+;                   ]
+;            :rules [
+;                     "it.time"
+;                     "it.numbers"
+;                     "it.cycles"
+;                     "it.duration"
+;                    ]}
 :cn$core {:corpus [
                     "cn.time"
                     "cn.numbers"
@@ -73,29 +73,29 @@
                      "cn.duration"
                      "cn.temperature"
                     ]}
-:ru$core {:corpus [
-                    "ru.numbers"
-                   ]
-            :rules [
-                     "ru.numbers"
-                    ]}
-
-:ar$core {:corpus [
-                    "ar.numbers"
-                   ]
-            :rules [
-                     "ar.numbers"
-                    ]}
-
-:ja$core {:corpus [
-                    "ja.numbers"
-                    "ja.temperature"
-                   ]
-            :rules [
-                     "ja.numbers"
-                     "ja.temperature"
-                     "ja.duration"
-                     "ja.cycles"
-                    ]}
+;:ru$core {:corpus [
+;                    "ru.numbers"
+;                   ]
+;            :rules [
+;                     "ru.numbers"
+;                    ]}
+;
+;:ar$core {:corpus [
+;                    "ar.numbers"
+;                   ]
+;            :rules [
+;                     "ar.numbers"
+;                    ]}
+;
+;:ja$core {:corpus [
+;                    "ja.numbers"
+;                    "ja.temperature"
+;                   ]
+;            :rules [
+;                     "ja.numbers"
+;                     "ja.temperature"
+;                     "ja.duration"
+;                     "ja.cycles"
+;                    ]}
  }
 

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,8 +1,8 @@
 # Root logger option
-log4j.rootLogger=DEBUG, console
+log4j.rootLogger=ERROR
 
 # Wit logger, only desired namespaces
-log4j.logger.duckling.core=DEBUG
+log4j.logger.duckling.core=ERROR
 
 # Direct log messages to console
 log4j.appender.console=org.apache.log4j.ConsoleAppender

--- a/src/duckling/learn.clj
+++ b/src/duckling/learn.clj
@@ -41,7 +41,7 @@
   [{<rule-name> [features, output]}]
   Output is true if the rule was contributing successfully, false otherwise"
   [s context check rules feature-extractor dataset]
-  (debugf "learning %s %s\n" s check)
+  ;(debugf "learning %s %s\n" s check)
   (let [fc-tokens (->> (engine/pass-all s rules nil)
                        (filter #(and (:pos %) (= (count s) (- (:end %) (:pos %)))))
                        (mapcat #(engine/resolve-token % context nil)) ; fully-covering tokens


### PR DESCRIPTION
No need to load language models that we aren't going to use. And we don't need to see all the logging either.
